### PR TITLE
chore: include .gitattributes for eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Every time I run the playground or build it, some files changed with CRLF in my Windows laptop (files not send when pushing)

![image](https://github.com/vuetifyjs/one/assets/6311119/ce945b52-fa9b-4e4d-b632-d0fdfdd7a245)
