### PR TITLE
fix(settings): Missing border in Odyssey theme

### DIFF
--- a/lib/stores/settings.ts
+++ b/lib/stores/settings.ts
@@ -151,7 +151,7 @@ function genThemes () {
         warning: '#ecb85b',
       },
       variables: {
-        'border-color': '#ffffff',
+        'border-color': '#000000',
         'border-opacity': 0.24,
         'high-emphasis-opacity': 1.0,
         'medium-emphasis-opacity': 0.87,


### PR DESCRIPTION
I don't think missing borders were the intention.

Before:

![image](https://github.com/vuetifyjs/one/assets/20162853/3371818f-5986-401d-83d6-ce0e8258fd93)

After:

![image](https://github.com/vuetifyjs/one/assets/20162853/6942560e-6b6f-45ff-9887-2e846288718b)
