### PR TITLE
fix(settings): high contrast readability of notifications content

### DIFF
--- a/lib/stores/settings.ts
+++ b/lib/stores/settings.ts
@@ -193,7 +193,7 @@ function genThemes () {
         'border-opacity': 0.87,
         'high-emphasis-opacity': 1.0,
         'medium-emphasis-opacity': 0.87,
-        'disabled-opacity': 0.5,
+        'disabled-opacity': 0.8,
         'idle-opacity': 0.1,
         'hover-opacity': 0.2,
         'focus-opacity': 0.3,


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/e5df6442-2456-4c8d-823b-bd92e229041a)

After:

![image](https://github.com/user-attachments/assets/22030679-4f91-4def-9a71-651196aef4d2)

