### PR TITLE
admin(PromotionsForm): zod errors

### DIFF
--- a/src/components/promotions/PromotionsForm.vue
+++ b/src/components/promotions/PromotionsForm.vue
@@ -10,10 +10,26 @@
       :value="promotions.record.id"
     >
 
+    <!-- Hidden inputs to show false value on initial unchecked checkbox -->
     <input
+      v-if="!promotions.record.metadata.active"
       name="metadata[active]"
       type="hidden"
       :value="promotions.record.metadata.active"
+    >
+
+    <input
+      v-if="!promotions.record.metadata.advertisement"
+      name="metadata[advertisement]"
+      type="hidden"
+      :value="promotions.record.metadata.advertisement"
+    >
+
+    <input
+      v-if="!promotions.record.metadata.discoverable"
+      name="metadata[discoverable]"
+      type="hidden"
+      :value="promotions.record.metadata.discoverable"
     >
 
     <v-card>


### PR DESCRIPTION
The main issue here was that the untouched `v-switch` elements for `Advertisement` and `Discoverable` were not being included in the form submission throwing a Zod type error.  I tried to use the 'false-value' prop on the `v-switch` but it did not work as I wanted to. 