### PR TITLE
docs: app bar fully visible in mobile

### DIFF
--- a/lib/components/app/VoAppBar.vue
+++ b/lib/components/app/VoAppBar.vue
@@ -27,7 +27,7 @@
 
       <v-divider
         v-if="$slots.append"
-        class="mx-4 align-self-center h-100"
+        class="align-self-center h-100 mx-2 mx-sm-4"
         length="20"
         vertical
       />

--- a/lib/components/auth/VoAuthBtn.vue
+++ b/lib/components/auth/VoAuthBtn.vue
@@ -14,13 +14,16 @@
       style="transition: .2s ease;"
       :variant="!auth.user ? 'flat' : one.isOpen ? 'outlined' : 'text'"
     >
-      <span v-if="!auth.user && smAndUp">Login</span> 
-      <v-icon v-if="!auth.user && !smAndUp">svg:{{mdiLogin}}</v-icon>
-
       <v-avatar
         v-if="auth.user"
         :image="user.avatar || auth.user.picture || ''"
       />
+
+      <template v-else>
+        <span v-if="smAndUp">Login</span>
+        <v-icon v-else :icon="`svg:${mdiLogin}`" />
+      </template>
+
 
       <VoUserMenu />
     </VoBtn>

--- a/lib/components/auth/VoAuthBtn.vue
+++ b/lib/components/auth/VoAuthBtn.vue
@@ -8,13 +8,14 @@
       :border="!!auth.user"
       class="vo-auth-btn"
       :color="color"
-      :icon="auth.user || auth.isLoading"
+      :icon="auth.user || auth.isLoading || !smAndUp"
       :loading="auth.isLoading"
-      size="default"
+      :size="smAndUp ? 'default' : 'small'"
       style="transition: .2s ease;"
       :variant="!auth.user ? 'flat' : one.isOpen ? 'outlined' : 'text'"
     >
-      <span v-if="!auth.user">Login</span>
+      <span v-if="!auth.user && smAndUp">Login</span> 
+      <v-icon v-if="!auth.user && !smAndUp">svg:{{mdiLogin}}</v-icon>
 
       <v-avatar
         v-if="auth.user"
@@ -53,4 +54,6 @@
         : user.colors.one
       : 'surface-light'
   })
+
+  const { smAndUp } = useDisplay()
 </script>


### PR DESCRIPTION
## Description
In mobile screens, the login button is cut off. This change will update the login button to an icon button.

Before:
![image](https://github.com/user-attachments/assets/fb15aa9c-cee4-4fbe-b6b1-b75afde999a0)

After:
<img width="321" alt="Screen Shot 2025-04-21 at 11 44 07 PM" src="https://github.com/user-attachments/assets/fb1943fd-a7ad-431d-a625-b6c3f652de02" />