### PR TITLE
docs: update README.md with Vuetify One branding and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-# Vuetify One
-
 <div align="center">
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://vuetifyjs.b-cdn.net/docs/images/one/logos/vone-logo-dark.png">
-  <img alt="Vuetify One Logo" src="https://vuetifyjs.b-cdn.net/docs/images/one/logos/vone-logo-light.png">
+  <img alt="Vuetify One Logo" src="https://vuetifyjs.b-cdn.net/docs/images/one/logos/vone-logo-light.png" height="150">
 </picture>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,69 +1,81 @@
-# essentials
+# Vuetify One
 
-## Project setup
+<div align="center">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://vuetifyjs.b-cdn.net/docs/images/one/logos/vone-logo-dark.png">
+  <img alt="Vuetify One Logo" src="https://vuetifyjs.b-cdn.net/docs/images/one/logos/vone-logo-light.png">
+</picture>
+</div>
 
-```
-# yarn
-yarn
+[![npm version](https://img.shields.io/npm/v/@vuetify/one.svg)](https://www.npmjs.com/package/@vuetify/one)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-# npm
-npm install
+## Overview
 
-# pnpm
+A collection of reusable components designed to seamlessly integrate Vuetify One services throughout the Vuetify ecosystem
+
+## Project Setup
+
+```bash
+git clone https://github.com/vuetifyjs/one.git
+
+cd one
+
 pnpm install
-
-# bun 
-bun install
 ```
 
-### Compiles and hot-reloads for development
+## Development
 
-```
-# yarn
-yarn dev
-
-# npm
-npm run dev
-
-# pnpm
+```bash
 pnpm dev
-
-# bun 
-bun run dev
 ```
 
-### Compiles and minifies for production
+## Building for Production
 
-```
-# yarn
-yarn build
-
-# npm
-npm run build
-
-# pnpm
+```bash
 pnpm build
-
-# bun 
-bun run build
 ```
 
-### Lints and fixes files
+## Linting
 
-```
-# yarn
-yarn lint
 
-# npm
-npm run lint
-
-# pnpm
+```bash
 pnpm lint
-
-# bun 
-bun run lint
 ```
 
-### Customize configuration
+## Usage
 
-See [Configuration Reference](https://vitejs.dev/config/).
+```js
+import { VoAppBar, VoAuthBtn, VoSocialFooter } from '@vuetify/one'
+
+export default {
+  components: {
+    VoAppBar,
+    VoAuthBtn,
+    VoSocialFooter
+  }
+}
+```
+## Store Integration
+
+```js
+import { useAuthStore, useOneStore, useProductsStore } from '@vuetify/one'
+
+const authStore = useAuthStore()
+const oneStore = useOneStore()
+```
+
+## License
+
+[MIT](http://opensource.org/licenses/MIT)
+
+Copyright (c) 2016-present Vuetify LLC
+
+----
+
+This project exists and thrives thanks to all the wonderful people who contribute 😍
+
+<br><br>
+<a href="https://github.com/vuetifyjs/one/graphs/contributors">
+<img src="https://contrib.rocks/image?repo=vuetifyjs/one" />
+</a>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://vuetifyjs.b-cdn.net/docs/images/one/logos/vone-logo-dark.png">
-  <img alt="Vuetify One Logo" src="https://vuetifyjs.b-cdn.net/docs/images/one/logos/vone-logo-light.png" height="150">
+  <source media="(prefers-color-scheme: dark)" srcset="https://vuetifyjs.b-cdn.net/docs/images/logos/vone-logo-dark.png">
+  <img alt="Vuetify One Logo" src="https://vuetifyjs.b-cdn.net/docs/images/logos/vone-logo-light.png" height="150">
 </picture>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </div>
 
 [![npm version](https://img.shields.io/npm/v/@vuetify/one.svg)](https://www.npmjs.com/package/@vuetify/one)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
 ## Overview
 


### PR DESCRIPTION
Update the README.md file to reflect the new branding for Vuetify One, including the logo, badges, and project overview. Also, standardize the project setup, development, and build instructions to use `pnpm` consistently.