### PR TITLE
refactor: remove onMounted from one store

### DIFF
--- a/src/stores/one.ts
+++ b/src/stores/one.ts
@@ -120,14 +120,6 @@ export const useOneStore = defineStore('one', (): OneState => {
     || monthlyTotal.value >= 2.99
   ))
 
-  // TODO: move this out because auth depends on it
-  // and auth is used outside of Vue instances
-  onMounted(async () => {
-    if (sessionId.value) {
-      await activate()
-    }
-  })
-
   watch(isOpen, resetQuery)
   watch(sessionId, async val => {
     if (!val) {


### PR DESCRIPTION
now that we have this watcher, the onMounted hook is no longer necessary

https://github.com/vuetifyjs/one/blob/8e57a7943cce793e4014ba2bb4e0aa71d8ae0270/src/stores/one.ts#L132