### PR TITLE
feat: export auth store as subpackage export

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./stores/auth": "./dist/stores/auth.js",
     "./styles": {
       "import": "./dist/index.css"
     },

--- a/rollup.types.config.js
+++ b/rollup.types.config.js
@@ -2,9 +2,10 @@ import { fileURLToPath } from 'node:url'
 import alias from '@rollup/plugin-alias'
 import dts from 'rollup-plugin-dts'
 
-export default {
+/** @type {import("rollup").RollupOptions[]} */
+const options = [{
   input: 'types-temp/src/index.d.ts',
-  output: [{ file: 'dist/index.d.ts', format: 'es', sourcemap: false }],
+  output: { file: 'dist/index.d.ts', format: 'es', sourcemap: false },
   plugins: [
     dts(),
     alias({
@@ -13,4 +14,17 @@ export default {
       ],
     }),
   ],
-}
+}, {
+  input: 'types-temp/src/stores/auth.d.ts',
+  output: { file: 'dist/stores/auth.d.ts', format: 'es', sourcemap: false },
+  plugins: [
+    dts(),
+    alias({
+      entries: [
+        { find: /^@\/(.*)/, replacement: fileURLToPath(new URL('types-temp/src/$1', import.meta.url)) },
+      ],
+    }),
+  ],
+}]
+
+export default options

--- a/vite.build.config.ts
+++ b/vite.build.config.ts
@@ -65,9 +65,13 @@ export default defineConfig({
   },
   build: {
     lib: {
-      entry: resolve(__dirname, './src/index.ts'),
-      name: 'VuetifyOne',
-      fileName: 'index',
+      // entry: resolve(__dirname, './src/index.ts'),
+      // name: 'VuetifyOne',
+      // fileName: 'index',
+      entry: {
+        'index': resolve(__dirname, './src/index.ts'),
+        'stores/auth': resolve(__dirname, './src/stores/auth.ts'),
+      },
       formats: ['es'],
     },
     rollupOptions: {


### PR DESCRIPTION
When trying to build v0 docs app, we're using the barrel from Vo to use `app` pinia plugina dn the `auth` store: since the package is a barrel with side effects, we cannot avoid bundling vuetify in the build.

This PR adds `store/auth` to the subpackage exports, the  `one` pinia plugin included copying the one function from the index module. Using this approach will remove the vuetify in the build => 300KB less of js/css (from 900KB to 600KB).

We can add more entries if required, will require some changes in the roolup type config file adding the new entries to the vite build config file.

_without this PR_
<img width="916" height="213" alt="image" src="https://github.com/user-attachments/assets/914d7343-3d46-4a6f-a7ed-dbd75b0a35c4" />

_with this PR as local tgz at v0_
<img width="1417" height="710" alt="image" src="https://github.com/user-attachments/assets/532dcea3-4ab1-4c92-94a7-143daaad55af" />

_changes at v0_
<img width="1706" height="892" alt="image" src="https://github.com/user-attachments/assets/085685dc-d618-41aa-9f6e-12ee7bbf9d79" />


