### PR TITLE
fix: replace MD2 typography classes with MD3 equivalents

### DIFF
--- a/packages/one/src/components/app/VoDialogSubheader.vue
+++ b/packages/one/src/components/app/VoDialogSubheader.vue
@@ -3,7 +3,7 @@
     {{ title }}
   </v-label>
 
-  <div v-if="text" class="mb-3 text-caption text-medium-emphasis">
+  <div v-if="text" class="mb-3 text-body-small text-medium-emphasis">
     {{ text }}
   </div>
 </template>

--- a/packages/one/src/components/app/VoMobileMenu.vue
+++ b/packages/one/src/components/app/VoMobileMenu.vue
@@ -20,7 +20,7 @@
 
       <template v-if="slots.title">
         <v-divider v-if="slots.prepend" class="mb-3" />
-        <div class="text-h6 mb-3">
+        <div class="text-title-large mb-3">
           <slot name="title" />
         </div>
       </template>

--- a/packages/one/src/components/app/VoSocialFooter.vue
+++ b/packages/one/src/components/app/VoSocialFooter.vue
@@ -24,7 +24,7 @@
     </a>
 
     <div
-      class="text-caption text-disabled"
+      class="text-body-small text-disabled"
       style="position: absolute; right: 16px;"
     >
       &copy; 2016-{{ (new Date()).getFullYear() }} <span class="d-none d-sm-inline-block">Vuetify, LLC</span>

--- a/packages/one/src/components/auth/VoAuthCard.vue
+++ b/packages/one/src/components/auth/VoAuthCard.vue
@@ -13,11 +13,11 @@
     </div>
 
     <div class="text-center mb-6">
-      <v-card-title class="text-h5 mb-1 text-md-h4">
-        <div class="text-h6 font-weight-light">
+      <v-card-title class="text-headline-small mb-1 text-md-headline-large">
+        <div class="text-title-large font-weight-light">
           {{ auth.lastLoginProvider() ? 'Welcome back to' : 'Login to' }}
         </div>
-        <span class="text-h3 font-weight-bold">Vuetify One</span>
+        <span class="text-display-medium font-weight-bold">Vuetify One</span>
       </v-card-title>
 
       <v-card-subtitle class="text-wrap">

--- a/packages/one/src/components/auth/VoAuthDiscord.vue
+++ b/packages/one/src/components/auth/VoAuthDiscord.vue
@@ -8,14 +8,14 @@
     @click="auth.login('discord')"
   >
     <template #title>
-      <span class="text-body-2">{{ text }}</span>
+      <span class="text-body-medium">{{ text }}</span>
     </template>
 
     <template
       v-if="(!auth.user && auth.lastLoginProvider() === 'discord')"
       #subtitle
     >
-      <div class="text-caption mt-n1">Last Used</div>
+      <div class="text-body-small mt-n1">Last Used</div>
     </template>
   </v-list-item>
 </template>

--- a/packages/one/src/components/auth/VoAuthGithub.vue
+++ b/packages/one/src/components/auth/VoAuthGithub.vue
@@ -8,14 +8,14 @@
     @click="auth.login('github')"
   >
     <template #title>
-      <span class="text-body-2">{{ text }}</span>
+      <span class="text-body-medium">{{ text }}</span>
     </template>
 
     <template
       v-if="(!auth.user && auth.lastLoginProvider() === 'github')"
       #subtitle
     >
-      <div class="text-caption mt-n1">Last Used</div>
+      <div class="text-body-small mt-n1">Last Used</div>
     </template>
   </v-list-item>
 </template>

--- a/packages/one/src/components/auth/VoAuthGoogle.vue
+++ b/packages/one/src/components/auth/VoAuthGoogle.vue
@@ -8,14 +8,14 @@
     @click="auth.login('google')"
   >
     <template #title>
-      <span class="text-body-2">{{ text }}</span>
+      <span class="text-body-medium">{{ text }}</span>
     </template>
 
     <template
       v-if="(!auth.user && auth.lastLoginProvider() === 'google')"
       #subtitle
     >
-      <div class="text-caption mt-n1">Last Used</div>
+      <div class="text-body-small mt-n1">Last Used</div>
     </template>
   </v-list-item>
 </template>

--- a/packages/one/src/components/auth/VoAuthOpenCollective.vue
+++ b/packages/one/src/components/auth/VoAuthOpenCollective.vue
@@ -8,14 +8,14 @@
     @click="auth.login('opencollective')"
   >
     <template #title>
-      <span class="text-body-2">{{ text }}</span>
+      <span class="text-body-medium">{{ text }}</span>
     </template>
 
     <template
       v-if="(!auth.user && auth.lastLoginProvider() === 'openCollective')"
       #subtitle
     >
-      <div class="text-caption mt-n1">Last Used</div>
+      <div class="text-body-small mt-n1">Last Used</div>
     </template>
   </v-list-item>
 </template>

--- a/packages/one/src/components/auth/VoAuthShopify.vue
+++ b/packages/one/src/components/auth/VoAuthShopify.vue
@@ -8,14 +8,14 @@
     @click="auth.login('shopify')"
   >
     <template #title>
-      <span class="text-body-2">{{ text }}</span>
+      <span class="text-body-medium">{{ text }}</span>
     </template>
 
     <template
       v-if="(!auth.user && auth.lastLoginProvider() === 'shopify')"
       #subtitle
     >
-      <div class="text-caption mt-n1">Last Used</div>
+      <div class="text-body-small mt-n1">Last Used</div>
     </template>
   </v-list-item>
 </template>

--- a/packages/one/src/components/notifications/VoNotificationsBanner.vue
+++ b/packages/one/src/components/notifications/VoNotificationsBanner.vue
@@ -30,7 +30,7 @@
 
       <v-list-item-title
         v-if="banner.metadata.text"
-        class="text-subtitle-2 text-md-subtitle-1 font-weight-medium"
+        class="text-title-small text-md-body-large font-weight-medium"
       >
         {{ banner.metadata.text }}
       </v-list-item-title>

--- a/packages/one/src/components/notifications/VoNotificationsBannerList.vue
+++ b/packages/one/src/components/notifications/VoNotificationsBannerList.vue
@@ -71,15 +71,15 @@
                   </template>
                 </v-tooltip>
 
-                <div class="text-subtitle-1 font-weight-bold">
+                <div class="text-body-large font-weight-bold">
                   {{ banner.metadata.text }}
                 </div>
 
-                <div class="text-caption font-weight-bold text-medium-emphasis">
+                <div class="text-body-small font-weight-bold text-medium-emphasis">
                   {{ date.format(banner.created_at, 'fullDateWithWeekday') }}
                 </div>
 
-                <div class="text-disabled text-caption mt-2 mb-3">
+                <div class="text-disabled text-body-small mt-2 mb-3">
                   {{ banner.metadata.subtext }}
                 </div>
 

--- a/packages/one/src/components/notifications/VoNotificationsDialog.vue
+++ b/packages/one/src/components/notifications/VoNotificationsDialog.vue
@@ -49,7 +49,7 @@
             value="read"
           >
             <template v-if="notifications.unread.length > 0" #append>
-              <span class="text-caption">
+              <span class="text-body-small">
                 {{ notifications.unread.length }}
               </span>
             </template>
@@ -61,7 +61,7 @@
             value="unread"
           >
             <template v-if="notifications.read.length > 0" #append>
-              <span class="text-caption">
+              <span class="text-body-small">
                 {{ notifications.read.length }}
               </span>
             </template>

--- a/packages/one/src/components/notifications/VoNotificationsListItem.vue
+++ b/packages/one/src/components/notifications/VoNotificationsListItem.vue
@@ -6,7 +6,7 @@
         class="py-4 mb-0"
       >
         <template #prepend>
-          <div class="ps-3 text-subtitle-2 pe-2">{{ notification.metadata.emoji }}</div>
+          <div class="ps-3 text-title-small pe-2">{{ notification.metadata.emoji }}</div>
         </template>
 
         <template #append>
@@ -33,15 +33,15 @@
           </v-responsive>
         </template>
 
-        <v-list-item-title class="text-wrap text-h6 mb-1">
+        <v-list-item-title class="text-wrap text-title-large mb-1">
           <div class=" text-truncate">{{ notification.title }}</div>
         </v-list-item-title>
 
-        <div class="text-caption font-weight-bold text-medium-emphasis">
+        <div class="text-body-small font-weight-bold text-medium-emphasis">
           {{ date.format(notification.created_at, 'fullDateWithWeekday') }}
         </div>
 
-        <div class="text-disabled text-caption my-2">
+        <div class="text-disabled text-body-small my-2">
           {{ notification.metadata.text }}
         </div>
 

--- a/packages/one/src/components/promotions/VoPromotionsCardVuetify.vue
+++ b/packages/one/src/components/promotions/VoPromotionsCardVuetify.vue
@@ -39,7 +39,7 @@
         />
 
         <div class="d-flex align-start ga-4">
-          <div class="text-caption on-surface-light">
+          <div class="text-body-small on-surface-light">
             {{ promotion.metadata?.text }}
           </div>
         </div>

--- a/packages/one/src/components/sponsorships/VoSponsorshipsPanel.vue
+++ b/packages/one/src/components/sponsorships/VoSponsorshipsPanel.vue
@@ -29,7 +29,7 @@
       </template>
 
       <template #text>
-        <div class="text-caption text-medium-emphasis">
+        <div class="text-body-small text-medium-emphasis">
           {{ one.isSubscriber ? 'You are currently receiving benefits of Vuetify One.' : 'Login to activate Vuetify One benefits' }}
         </div>
       </template>

--- a/packages/one/src/components/subscription/VoSubscriptionInvoices.vue
+++ b/packages/one/src/components/subscription/VoSubscriptionInvoices.vue
@@ -15,7 +15,7 @@
           sticky
         >
           <template #item.date="{ item }">
-            <div class="text-caption">
+            <div class="text-body-small">
               {{ date.format(new Date(item.date * 1000), 'fullDateWithWeekday') }}
             </div>
           </template>

--- a/packages/one/src/components/subscription/VoSubscriptionPerks.vue
+++ b/packages/one/src/components/subscription/VoSubscriptionPerks.vue
@@ -1,7 +1,7 @@
 <template>
   <v-label class="font-weight-black">Perks</v-label>
 
-  <div class="mb-3 text-caption text-medium-emphasis">
+  <div class="mb-3 text-body-small text-medium-emphasis">
     The Vuetify One subscription comes with the following perks:
   </div>
 
@@ -26,7 +26,7 @@
 
   <v-label class="font-weight-black">Up Next</v-label>
 
-  <div class="mb-3 text-caption text-medium-emphasis">
+  <div class="mb-3 text-body-small text-medium-emphasis">
     The following features are in development and coming soon:
   </div>
 

--- a/packages/one/src/components/subscription/VoSubscriptionStatus.vue
+++ b/packages/one/src/components/subscription/VoSubscriptionStatus.vue
@@ -20,7 +20,7 @@
               <span class="mx-1 hidden-sm-and-down">—</span>
 
               <span class="me-1">
-                ${{ one.info.items[0].plan.amount / 100 }}<span class="text-medium-emphasis text-caption">/{{ one.interval }}</span>
+                ${{ one.info.items[0].plan.amount / 100 }}<span class="text-medium-emphasis text-body-small">/{{ one.interval }}</span>
               </span>
 
               <VoBtn
@@ -65,7 +65,7 @@
         </template>
       </v-card>
 
-      <div class="d-flex align-start justify-space-between text-caption py-2">
+      <div class="d-flex align-start justify-space-between text-body-small py-2">
         <div>
           <template v-if="one.info?.status === 'active'">
             Your plan renews on <span class="font-weight-bold">

--- a/packages/one/src/components/user/VoUserAvatar.vue
+++ b/packages/one/src/components/user/VoUserAvatar.vue
@@ -58,7 +58,7 @@
       </v-expand-transition>
     </div>
 
-    <div class="text-h6">
+    <div class="text-title-large">
       {{ auth.user?.name ?? 'Guest' }}
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Replaces all MD2 typography utility classes (`text-h1`-`text-h6`, `text-subtitle-1/2`, `text-body-1/2`, `text-button`, `text-caption`, `text-overline`) with their MD3 equivalents across 19 components.
- These classes no longer apply any styling under the Vuetify 4 peer dep — mapping follows the [upgrade-guide table](https://github.com/vuetifyjs/vuetify/blob/master/packages/docs/src/pages/en/getting-started/upgrade-guide.md#typography-codemod-available).
- Includes responsive prefix variants (`text-md-h4` → `text-md-headline-large`).

## Mapping applied

| MD2 | MD3 |
|---|---|
| `text-h1` / `text-h2` | `text-display-large` |
| `text-h3` | `text-display-medium` |
| `text-h4` | `text-headline-large` |
| `text-h5` | `text-headline-small` |
| `text-h6` | `text-title-large` |
| `text-subtitle-1` / `text-body-1` | `text-body-large` |
| `text-subtitle-2` | `text-title-small` |
| `text-body-2` | `text-body-medium` |
| `text-button` | `text-label-large` |
| `text-caption` | `text-body-small` |
| `text-overline` | `text-label-medium` |

## Heads up — follow-up needed after #50 merges

The in-flight `haviles04/snips-one-subscription` branch (PR #50) renames `VoSubscriptionPerks.vue` → `VoSubscriptionSubscribe.vue` and reintroduces ~8 MD2 classes that don't exist on master. After that PR merges, re-run the same sweep on `VoSubscriptionSubscribe.vue` (or rebase this branch onto it before merging).

## Test plan

- [x] `pnpm typecheck` passes
- [x] Visual check: Vuetify One auth card, notification list/banner, subscription panel, promotion cards
- [x] Confirm responsive variants (`text-md-headline-large`) render at md breakpoint